### PR TITLE
Fix inheritance chain

### DIFF
--- a/lib/passport-stripe/strategy.js
+++ b/lib/passport-stripe/strategy.js
@@ -68,7 +68,7 @@ util.inherits(Strategy, OAuth2Strategy);
  * @param {Object} req
  * @api protected
  */
-OAuth2Strategy.prototype.authenticate = function(req, options) {
+Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var self = this;
 
@@ -153,7 +153,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
 * @param {Object} options
 */
 
-OAuth2Strategy.prototype.authorizationParams = function(options){
+Strategy.prototype.authorizationParams = function(options){
     return options;
 };
 


### PR DESCRIPTION
Fixes an issue where this module overwrites the OAuth2Strategy prototype `authenticate` method, which can cause other OAuth2 passport modules to use this overridden method.
