### PR TITLE
Fix relative callback URL functionality in Express

### DIFF
--- a/lib/passport-stripe/strategy.js
+++ b/lib/passport-stripe/strategy.js
@@ -84,7 +84,7 @@ Strategy.prototype.authenticate = function(req, options) {
     if (!parsed.protocol) {
       // The callback URL is relative, resolve a fully qualified URL from the
       // URL of the originating request.
-      callbackURL = url.resolve(req.originalURL, callbackURL);
+      callbackURL = url.resolve(req.originalUrl, callbackURL);
     }
   }
 


### PR DESCRIPTION
Assuming the relative callback URL functionality is supposed to work in Express (I am using Express 4) I think there is a typo.

This should address it and allow this feature to work.